### PR TITLE
Scope name for G-Code grammar

### DIFF
--- a/bin/(GCode).tmLanguage
+++ b/bin/(GCode).tmLanguage
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.syntax_name</string>
+	<string>source.gcode</string>
 	<key>uuid</key>
 	<string>32ab95f2-a394-46ee-9e83-9d93b9de5f19</string>
 </dict>

--- a/src/(GCode).JSON-tmLanguage
+++ b/src/(GCode).JSON-tmLanguage
@@ -1,5 +1,5 @@
 { "name": "GCode",
-  "scopeName": "source.syntax_name",
+  "scopeName": "source.gcode",
   "fileTypes": ["nc"],
   "patterns": [
 	{ 	


### PR DESCRIPTION
It looks like your G-Code grammar is [missing a scope name](https://github.com/robotmaster/sublime-text-syntax-highlighting/blob/master/src/%28GCode%29.JSON-tmLanguage#L2)...?
This pull request adds `source.gcode` as the scope name.